### PR TITLE
feat: add channel assignment for directives

### DIFF
--- a/.metanorma/channels.yml
+++ b/.metanorma/channels.yml
@@ -1,0 +1,5 @@
+# .metanorma/channels.yml — CalConnect Directive: Standardization and Publication
+
+channels:
+  - name: public/directives
+    description: "CalConnect directives"

--- a/metanorma.release.yml
+++ b/metanorma.release.yml
@@ -1,2 +1,5 @@
+# metanorma.release.yml — CalConnect Directive: Standardization and Publication
+
 documents:
   - source: sources/cc-10001.adoc
+    channels: [public/directives]


### PR DESCRIPTION
Assign `public/directives` channel to `cc-10001` and add `.metanorma/channels.yml` for efficient repo discovery by `actions-mn/aggregate`.